### PR TITLE
Add latency parameter to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ testing infrastructure on top of pretender and need to fail tests that have hand
 
 Each handler keeps a count of the number of requests is successfully served.
 
+## Other config
+**latency (ms)**
+Set an artificial delay on all your responses with `this.latency`.
+
+```javascript
+var server = new Pretender(function(){
+  this.latency = 200;
+});
+```
+
 ## Clean up
 When you're done mocking, be sure to call `shutdown()` to restore the native XMLHttpRequest object:
 

--- a/pretender.js
+++ b/pretender.js
@@ -22,6 +22,9 @@ function Pretender(maps){
   this.passthroughRequests = [];
   this.unhandledRequests = [];
 
+  // default latency
+  this.latency = this.latency || 0;
+
   // reference the native XMLHttpRequest object so
   // it can be restored later
   this._nativeXMLHttpRequest = window.XMLHttpRequest;
@@ -53,7 +56,11 @@ function interceptor(pretender) {
 
     FakeXMLHttpRequest.prototype.send.apply(this, arguments);
     if (!pretender.checkPassthrough(this)) {
-      pretender.handleRequest(this);
+      var _this = this;
+
+      setTimeout(function() {
+        pretender.handleRequest(_this);
+      }, pretender.latency);
     }
     else {
       var xhr = createPassthrough(this);


### PR DESCRIPTION
I'm starting to use pretender as my fake server for clicking around my apps. Having the ability to simulate latency (like in Ember Fixture adapter) would be great.