### PR TITLE
Require FakeXMLHttpRequest 1.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "./pretender.js"
   ],
   "dependencies": {
-    "FakeXMLHttpRequest": "~1.0.0",
+    "FakeXMLHttpRequest": "~1.2.0",
     "route-recognizer": "~0.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "route-recognizer": "^0.1.0",
-    "fake-xml-http-request": "^1.0.0"
+    "fake-xml-http-request": "^1.2.0"
   }
 }


### PR DESCRIPTION
Require the just released 1.2 version of FakeXMLHttpRequest