### PR TITLE
Adding passthroughURL to allow all requests for URL to be passed through

### DIFF
--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -35,3 +35,34 @@ asyncTest("allows matched paths to be pass-through", function(){
     }
   });
 });
+
+asyncTest("allows requests for URL to be pass-through", function(){
+  pretender.passthroughURL = true;
+
+  var passthroughInvoked = false;
+  pretender.passthroughRequest = function(verb, path, request) {
+    passthroughInvoked = true;
+    equal(verb, 'POST');
+    equal(path, 'http://www.google.com');
+    equal(request.requestBody, 'some=data');
+  };
+
+  $.ajax({
+    url: 'http://www.google.com',
+    method: 'POST',
+    headers: {
+      'test-header': 'value'
+    },
+    data: {
+      'some': 'data'
+    },
+    async: false,
+    error: function(xhr) {
+      equal(xhr.status, 0);
+      ok(passthroughInvoked);
+      start();
+    }
+  });
+});
+
+


### PR DESCRIPTION
In our tests, we need to send an URL request out to a express server. With pretender as it is currently, we do not have a way to to do this.
This flag would allow URL requests to be passed through.