### PR TITLE
Add phantom to karma and fix passthrough test timing issue.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -60,7 +60,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome'],
+    browsers: ['Chrome', 'PhantomJS'],
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bower": "^1.3.5",
     "karma": "^0.12.16",
     "karma-chrome-launcher": "^0.1.3",
+    "karma-phantomjs-launcher": "0.2.0",
     "karma-qunit": "^0.1.3"
   },
   "dependencies": {

--- a/pretender.js
+++ b/pretender.js
@@ -66,10 +66,18 @@ function interceptor(pretender) {
   };
 
   // passthrough handling
-  var evts = ['load', 'error', 'timeout', 'progress', 'abort', 'readystatechange'];
+  var evts = ['error', 'timeout', 'progress', 'abort'];
   var lifecycleProps = ['readyState', 'responseText', 'responseXML', 'status', 'statusText'];
   function createPassthrough(fakeXHR) {
     var xhr = fakeXHR._passthroughRequest = new pretender._nativeXMLHttpRequest();
+
+    // use onload instead of onreadystatechange if the browser supports it
+    if ('onload' in xhr) {
+      evts.push('load');
+    } else {
+      evts.push('readystatechange');
+    }
+
     // listen to all events to update lifecycle properties
     for (var i = 0; i < evts.length; i++) (function(evt) {
       xhr['on' + evt] = function(e) {

--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -273,7 +273,7 @@ test("can be configured to resolve after a specified time", function(assert) {
 
   pretender.get('/some/path', function(request) {
     return [200, {}, ''];
-  }, 10);
+  }, 100);
 
   $.ajax({
     url: '/some/path',


### PR DESCRIPTION
There were 2 things going on:
* phantomjs and `onreadystatechange` do not like each other. Simply trying to access `xhr['onreadystatechange']` would throw an error. This PR uses `onload` if its available with a fallback to `onreadystatechange` if it's not.
* the `setTimeout` call w/ a 0 delay was coming back after the ajax request had already completed in phantom. I bumped the ajax request response timing up to 100 ms to avoid issues.

Thanks to @kategengler for pointing out a [similar issue in mockjax](https://github.com/jakerella/jquery-mockjax/blob/master/src/jquery.mockjax.js#L222) which helped narrow down the root problem.

Fixes #74